### PR TITLE
🌱 Add SECURITY_CONTACTS.md

### DIFF
--- a/SECURITY_CONTACTS.md
+++ b/SECURITY_CONTACTS.md
@@ -1,0 +1,14 @@
+<!--security-contacts-start-->
+Defined below are the security contacts for this repo.
+
+They are the contact point for the Product Security Committee to reach out
+to for triaging and handling of incoming issues.
+
+The below names agree to address security concerns if and when they arise.
+
+DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, SEND INFORMATION
+TO [kubestellar-security-announce@googlegroups.com](mailto:kubestellar-security-announce@googlegroups.com)
+
+clubanderson<br/>
+MikeSpreitzer<br/>
+<!--security-contacts-end-->


### PR DESCRIPTION
## Summary
- Adds SECURITY_CONTACTS.md so repos created from this template inherit the standard security contacts (clubanderson, MikeSpreitzer)

## Test plan
- [ ] Verify SECURITY_CONTACTS.md renders correctly